### PR TITLE
Add features for `Account`

### DIFF
--- a/ain/account.py
+++ b/ain/account.py
@@ -1,0 +1,43 @@
+from typing import Dict, Union
+from ain.utils import (
+    privateToPublic,
+    privateToAddress,
+    mnemonicToPrivatekey,
+)
+
+class Account:
+    private_key: str
+    public_key: str
+    address: str
+    
+    def __init__(self, privateKey: Union[bytes, str] = None):
+        if type(privateKey) is bytes:
+            privateKeyBytes = privateKey
+        elif type(privateKey) is str:
+            privateKeyBytes = bytes.fromhex(privateKey)
+        else:
+            raise TypeError('privateKey has invalid type')
+
+        self.private_key = privateKeyBytes.hex()
+        self.public_key = privateToPublic(privateKeyBytes).hex()
+        self.address = privateToAddress(privateKeyBytes)
+
+    @classmethod
+    def fromMnemonic(cls, mnemonic: str, index: int = 0):
+        """
+        Returns an Account with the given mnemonic.
+        """
+        return cls(mnemonicToPrivatekey(mnemonic, index))
+
+    def __str__(self):
+        return "\n".join(
+            (
+                "{",
+                f"  address: '{self.address}'",
+                f"  private: '{self.private_key}'",
+                f"  public: '{self.public_key}'",
+                "}",
+            )
+        )
+
+Accounts = Dict[str, Account]

--- a/ain/account.py
+++ b/ain/account.py
@@ -32,7 +32,7 @@ class Account:
         return cls(mnemonicToPrivatekey(mnemonic, index))
 
     @classmethod
-    def fromEntropy(cls, entropy: str = None):
+    def create(cls, entropy: str = None):
         entropyBytes = token_bytes(32)
         if entropy is not None:
             entropyBytes = bytes(entropy, "utf-8")

--- a/ain/account.py
+++ b/ain/account.py
@@ -1,8 +1,10 @@
 from typing import Dict, Union
+from secrets import token_bytes
 from ain.utils import (
     privateToPublic,
     privateToAddress,
     mnemonicToPrivatekey,
+    keccak
 )
 
 class Account:
@@ -28,6 +30,16 @@ class Account:
         Returns an Account with the given mnemonic.
         """
         return cls(mnemonicToPrivatekey(mnemonic, index))
+
+    @classmethod
+    def fromEntropy(cls, entropy: str = None):
+        entropyBytes = token_bytes(32)
+        if entropy is not None:
+            entropyBytes = bytes(entropy, "utf-8")
+
+        innerHex = keccak(token_bytes(32) + entropyBytes)
+        middleHex = token_bytes(32) + innerHex + token_bytes(32)
+        return cls(keccak(middleHex))
 
     def __str__(self):
         return "\n".join(

--- a/ain/utils.py
+++ b/ain/utils.py
@@ -7,7 +7,8 @@ from coincurve import PrivateKey, PublicKey
 from coincurve.ecdsa import deserialize_recoverable, recoverable_convert, cdata_to_der
 from coincurve.utils import verify_signature, validate_secret
 from mnemonic import Mnemonic
-from bip32 import BIP32
+# TODO(kriii): Need to replace bip32 package or wait for the type hint.
+from bip32 import BIP32 # type: ignore
 from ain.types import ECDSASignature, TransactionBody
 
 def encodeVarInt(number: int) -> bytes:

--- a/ain/utils.py
+++ b/ain/utils.py
@@ -331,10 +331,6 @@ def decryptWithPrivateKey():
     pass
 
 # TODO(kriii): implement this function.
-def createAccount():
-    pass
-
-# TODO(kriii): implement this function.
 def privateToV3Keystore():
     pass
 

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
+from ain.account import Account, Accounts
 from ain.types import (
     TransactionBody,
     ValueOnlyTransactionInput,
@@ -9,9 +10,6 @@ from ain.utils import (
     toChecksumAddress,
     bytesToHex,
     pubToAddress,
-    privateToPublic,
-    privateToAddress,
-    mnemonicToPrivatekey,
     ecSignMessage,
     ecSignTransaction,
     ecRecoverPub,
@@ -20,43 +18,6 @@ from ain.utils import (
 
 if TYPE_CHECKING:
     from ain.ain import Ain
-
-class Account:
-    private_key: str
-    public_key: str
-    address: str
-    
-    def __init__(self, privateKey: Union[bytes, str] = None):
-        if type(privateKey) is bytes:
-            privateKeyBytes = privateKey
-        elif type(privateKey) is str:
-            privateKeyBytes = bytes.fromhex(privateKey)
-        else:
-            raise TypeError('privateKey has invalid type')
-
-        self.private_key = privateKeyBytes.hex()
-        self.public_key = privateToPublic(privateKeyBytes).hex()
-        self.address = privateToAddress(privateKeyBytes)
-
-    @classmethod
-    def fromMnemonic(cls, mnemonic: str, index: int = 0):
-        """
-        Returns an Account with the given mnemonic.
-        """
-        return cls(mnemonicToPrivatekey(mnemonic, index))
-
-    def __str__(self):
-        return "\n".join(
-            (
-                "{",
-                f"  address: '{self.address}'",
-                f"  private: '{self.private_key}'",
-                f"  public: '{self.public_key}'",
-                "}",
-            )
-        )
-
-Accounts = Dict[str, Account]
 
 class Wallet:
     defaultAccount: Optional[Account]

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -11,6 +11,7 @@ from ain.utils import (
     pubToAddress,
     privateToPublic,
     privateToAddress,
+    mnemonicToPrivatekey,
     ecSignMessage,
     ecSignTransaction,
     ecRecoverPub,
@@ -36,6 +37,13 @@ class Account:
         self.private_key = privateKeyBytes.hex()
         self.public_key = privateToPublic(privateKeyBytes).hex()
         self.address = privateToAddress(privateKeyBytes)
+
+    @classmethod
+    def fromMnemonic(cls, mnemonic: str, index: int = 0):
+        """
+        Returns an Account with the given mnemonic.
+        """
+        return cls(mnemonicToPrivatekey(mnemonic, index))
 
     def __str__(self):
         return "\n".join(

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,5 @@ pycryptodome
 coincurve
 aiohttp[speedups]
 jsonrpcclient
+mnemonic
+bip32

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ requirements = [
     "coincurve",
     "aiohttp[speedups]",
     "jsonrpcclient",
+    "mnemonic",
+    "bip32",
 ]
 
 test_requirements = []

--- a/tests/test_ain_account.py
+++ b/tests/test_ain_account.py
@@ -15,7 +15,7 @@ class TestAccount(TestCase):
         self.assertEqual(account.public_key, mnemonicPublicKey.hex())
         self.assertEqual(account.address, mnemonicAddress)
     
-    def testAccountFromEntropyNone(self):
-        account = Account.fromEntropy()
+    def testAccountCreateFromEntropyNone(self):
+        account = Account.create()
         publicKey = privateToPublic(bytes.fromhex(account.private_key)).hex()
         self.assertEqual(account.public_key, publicKey)

--- a/tests/test_ain_account.py
+++ b/tests/test_ain_account.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from ain.account import Account
+from ain.utils import *
+from .data import (
+    mnemonic,
+    mnemonicPrivateKey,
+    mnemonicPublicKey,
+    mnemonicAddress,
+)
+
+class TestAccount(TestCase):
+    def testAccountFromMnemonic(self):
+        account = Account.fromMnemonic(mnemonic)
+        self.assertEqual(account.private_key, mnemonicPrivateKey.hex())
+        self.assertEqual(account.public_key, mnemonicPublicKey.hex())
+        self.assertEqual(account.address, mnemonicAddress)
+    
+    def testAccountFromEntropyNone(self):
+        account = Account.fromEntropy()
+        publicKey = privateToPublic(bytes.fromhex(account.private_key)).hex()
+        self.assertEqual(account.public_key, publicKey)

--- a/tests/test_ain_account.py
+++ b/tests/test_ain_account.py
@@ -19,3 +19,8 @@ class TestAccount(TestCase):
         account = Account.create()
         publicKey = privateToPublic(bytes.fromhex(account.private_key)).hex()
         self.assertEqual(account.public_key, publicKey)
+
+    def testAccountCreateFromEntropy(self):
+        account = Account.create("Test")
+        publicKey = privateToPublic(bytes.fromhex(account.private_key)).hex()
+        self.assertEqual(account.public_key, publicKey)

--- a/tests/test_ain_utils.py
+++ b/tests/test_ain_utils.py
@@ -189,9 +189,6 @@ class TestMnemonicToPrivatekey(TestCase):
 # TODO(kriii): Add tests after implement `encryptWithPublicKey` and `decryptWithPrivateKey`.
 # class TestEncryption(TestCase):
 
-# TODO(kriii): Add tests after implement `createAccount`.
-# class TestCreateAccount(TestCase):
-
 # TODO(kriii): Add tests after implement `encode`.
 # class TestEncode(TestCase):
 

--- a/tests/test_ain_utils.py
+++ b/tests/test_ain_utils.py
@@ -182,6 +182,10 @@ class TestEcVerifySig(TestCase):
     def testEcVerifySigDifferentMessage(self):
         self.assertFalse(ecVerifySig("Hello World", correctSignature, address))
 
+class TestMnemonicToPrivatekey(TestCase):
+    def testMnemonicToPrivatekey(self):
+        self.assertEqual(mnemonicToPrivatekey(mnemonic), mnemonicPrivateKey)
+
 # TODO(kriii): Add tests after implement `encryptWithPublicKey` and `decryptWithPrivateKey`.
 # class TestEncryption(TestCase):
 


### PR DESCRIPTION
Changes:
- Support mnemonic
- Separate `Account` and `Wallet`
- Support creating `Account` from entropy

I have a curiosity about function [concatHexPrefixed](https://github.com/ainblockchain/ain-util/blob/master/src/index.ts#L839-L841). Why does it slice `b`?

And some notes about mnemonic:
It seems there are two methods to support mnemonic, and they have cons resp.
1. use `bip-utils` - I had many failures to install because this required installing `rust` and doing some settings. But it was for the installing subpackage meaningless about mnemonic.
2. use `mnemonic` and `bip32` - Easy to install, but `bip32` doesn't support type hinting, so `mypy` hates it.

The chosen option is the second with ignored the type hint.