### PR TITLE
Add coverage of `Literal`, etc

### DIFF
--- a/ain/ain.py
+++ b/ain/ain.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union
 from ain.provider import Provider
 from ain.net import Network
 from ain.wallet import Wallet

--- a/ain/ain_db/ref.py
+++ b/ain/ain_db/ref.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import TYPE_CHECKING, Any, List, Optional
 from ain.types import (
     SetOperation,

--- a/ain/provider.py
+++ b/ain/provider.py
@@ -1,7 +1,5 @@
 import aiohttp
-import asyncio
 import json
-import inspect
 from urllib.parse import urlparse, urljoin
 from jsonrpcclient import request, parse, Ok, Error
 from typing import TYPE_CHECKING, Any

--- a/ain/types.py
+++ b/ain/types.py
@@ -1,4 +1,10 @@
-from typing import Any, Literal, Optional, List, Union
+import sys
+from typing import Any, Optional, List, Union
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 class ECDSASignature:
     r: bytes

--- a/ain/utils.py
+++ b/ain/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Union
 from Crypto.Hash import keccak as _keccak
 from coincurve import PrivateKey, PublicKey
 from coincurve.ecdsa import deserialize_recoverable, recoverable_convert, cdata_to_der
-from coincurve.utils import verify_signature, validate_secret
+from coincurve.utils import validate_secret
 from mnemonic import Mnemonic
 # TODO(kriii): Need to replace bip32 package or wait for the type hint.
 from bip32 import BIP32 # type: ignore

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+typing-extensions
 pycryptodome
 coincurve
 aiohttp[speedups]

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/ainblockchain/ain-py",
-    version="0.1.0",
+    version="0.1.1",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 requirements = [
+    "typing-extensions",
     "pycryptodome",
     "coincurve",
     "aiohttp[speedups]",
@@ -25,6 +26,7 @@ setup(
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/test_ain_utils.py
+++ b/tests/test_ain_utils.py
@@ -6,8 +6,6 @@ from .data import (
     sk,
     mnemonic,
     mnemonicPrivateKey,
-    mnemonicPublicKey,
-    mnemonicAddress,
     checksumAddresses,
     message,
     correctSignature,
@@ -112,12 +110,6 @@ class TestPrivateToPublic(TestCase):
 class TestPrivateToAddress(TestCase):
     def testPrivateToAddress(self):
         self.assertEqual(privateToAddress(sk), address)
-
-# TODO(kriii): Add tests after implement `mnemonicToPrivatekey`.
-# class TestMnemonicToPrivatekey(TestCase):
-
-# TODO(kriii): Add tests after implement `mnemonicToAccount`.
-# class TestMnemonicToAccount(TestCase):
 
 # TODO(kriii): Add tests after implement `V3Keystore` methods.
 # class TestV3KeyStore(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py37,py38,py39,py310
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
There was a request that should support Python 3.7, so fixed. And removed some unused things.