### PR TITLE
Add ECIES encrypt/decrypt

### DIFF
--- a/ain/types.py
+++ b/ain/types.py
@@ -36,7 +36,7 @@ class ECDSASignature:
         v = signature[64]
         return cls(r, s, v)
 
-class ECDHEncrypted:
+class ECIESEncrypted:
     iv: bytes
     ephemPublicKey: bytes
     ciphertext: bytes

--- a/ain/types.py
+++ b/ain/types.py
@@ -36,6 +36,36 @@ class ECDSASignature:
         v = signature[64]
         return cls(r, s, v)
 
+class ECDHEncrypted:
+    iv: bytes
+    ephemPublicKey: bytes
+    ciphertext: bytes
+    mac: bytes
+
+    def __init__(
+        self,
+        iv: bytes,
+        ephemPublicKey: bytes,
+        ciphertext: bytes,
+        mac: bytes,
+    ):
+        self.iv = iv
+        self.ephemPublicKey = ephemPublicKey
+        self.ciphertext = ciphertext
+        self.mac = mac
+
+    def __str__(self):
+        return "\n".join(
+            (
+                "{",
+                f"  iv: '{self.iv.hex()}',",
+                f"  ephemPublicKey: '{self.ephemPublicKey.hex()}',",
+                f"  ciphertext: '{self.ciphertext.hex()}',",
+                f"  mac: '{self.mac.hex()}',",
+                "}",
+            )
+        )
+
 SetMultiOperationType = Literal["SET"]
 
 GetMultiOperationType = Literal["GET"]

--- a/ain/utils.py
+++ b/ain/utils.py
@@ -2,14 +2,19 @@ import re
 import json
 import time
 from typing import Any, Union
+from secrets import token_bytes
+from Crypto import Cipher
+from Crypto.Cipher import AES
 from Crypto.Hash import keccak as _keccak
+from Crypto.Hash import HMAC, SHA256, SHA512
+from Crypto.Util.Padding import pad, unpad
 from coincurve import PrivateKey, PublicKey
 from coincurve.ecdsa import deserialize_recoverable, recoverable_convert, cdata_to_der
 from coincurve.utils import validate_secret
 from mnemonic import Mnemonic
 # TODO(kriii): Need to replace bip32 package or wait for the type hint.
 from bip32 import BIP32 # type: ignore
-from ain.types import ECDSASignature, TransactionBody
+from ain.types import ECDSASignature, ECDHEncrypted, TransactionBody
 
 def encodeVarInt(number: int) -> bytes:
     """
@@ -322,13 +327,67 @@ def mnemonicToPrivatekey(mnemonic: str, index: int = 0) -> bytes:
     path = AIN_HD_DERIVATION_PATH + f"{index}"
     return bip32.get_privkey_from_path(path)
 
-# TODO(kriii): implement this function.
-def encryptWithPublicKey():
-    pass
+def encryptWithPublicKey(publicKey: Union[bytes, str], message: str) -> ECDHEncrypted:
+    """
+    Encrypts message with publicKey.
+    """
+    if type(publicKey) is str:
+        publicKeyBytes = bytes.fromhex(publicKey)
+    elif type(publicKey) is bytes:
+        publicKeyBytes = publicKey
+    else:
+        raise ValueError("Invalid public key type")
 
-# TODO(kriii): implement this function.
-def decryptWithPrivateKey():
-    pass
+    if len(publicKeyBytes) == 64:
+        publicKeyBytes = bytes([4]) + publicKeyBytes
+
+    pbK = PublicKey(publicKeyBytes)
+    epK = PrivateKey()
+    ephemPublicKey = epK.public_key.format(False)
+    shared = pbK.multiply(epK.secret)
+    derive = shared.format(True)[1:]
+    hash = SHA512.new()
+    hash.update(derive)
+    iv = token_bytes(16)
+    encKey = hash.digest()[0:32]
+    aes = AES.new(encKey, AES.MODE_CBC, iv=iv)
+    ciphertext = aes.encrypt(pad(toBytes(message), 16))
+    macKey = hash.digest()[32:]
+    hmac = HMAC.new(macKey, digestmod=SHA256)
+    hmac.update(iv + ephemPublicKey + ciphertext)
+    mac = hmac.digest()
+
+    return ECDHEncrypted(iv, ephemPublicKey, ciphertext, mac)
+
+def decryptWithPrivateKey(privateKey: Union[bytes, str], encrypted: ECDHEncrypted) -> str:
+    """
+    Decrypts encrypted data with privateKey.
+    """
+    if type(privateKey) is str:
+        privateKeyBytes = bytes.fromhex(privateKey)
+    elif type(privateKey) is bytes:
+        privateKeyBytes = privateKey
+    else:
+        raise ValueError("Invalid public key type")
+
+    prK = PrivateKey(privateKeyBytes)
+    epK = PublicKey(encrypted.ephemPublicKey)
+    shared = epK.multiply(prK.secret)
+    derive = shared.format(True)[1:]
+    hash = SHA512.new()
+    hash.update(derive)
+    encKey = hash.digest()[0:32]
+    macKey = hash.digest()[32:]
+    hmac = HMAC.new(macKey, digestmod=SHA256)
+    hmac.update(encrypted.iv + encrypted.ephemPublicKey + encrypted.ciphertext)
+    mac = hmac.digest()
+
+    if mac != encrypted.mac:
+        raise ValueError("Bad MAC")
+
+    aes = AES.new(encKey, AES.MODE_CBC, iv=encrypted.iv)
+    plaintext = unpad(aes.decrypt(encrypted.ciphertext), 16)
+    return plaintext.decode("utf-8")
 
 # TODO(kriii): implement this function.
 def privateToV3Keystore():

--- a/ain/utils.py
+++ b/ain/utils.py
@@ -14,7 +14,7 @@ from coincurve.utils import validate_secret
 from mnemonic import Mnemonic
 # TODO(kriii): Need to replace bip32 package or wait for the type hint.
 from bip32 import BIP32 # type: ignore
-from ain.types import ECDSASignature, ECDHEncrypted, TransactionBody
+from ain.types import ECDSASignature, ECIESEncrypted, TransactionBody
 
 def encodeVarInt(number: int) -> bytes:
     """
@@ -327,7 +327,8 @@ def mnemonicToPrivatekey(mnemonic: str, index: int = 0) -> bytes:
     path = AIN_HD_DERIVATION_PATH + f"{index}"
     return bip32.get_privkey_from_path(path)
 
-def encryptWithPublicKey(publicKey: Union[bytes, str], message: str) -> ECDHEncrypted:
+# NOTE(kriii): Referenced https://github.com/bitchan/eccrypto/blob/master/index.js#L195-L258
+def encryptWithPublicKey(publicKey: Union[bytes, str], message: str) -> ECIESEncrypted:
     """
     Encrypts message with publicKey.
     """
@@ -357,9 +358,9 @@ def encryptWithPublicKey(publicKey: Union[bytes, str], message: str) -> ECDHEncr
     hmac.update(iv + ephemPublicKey + ciphertext)
     mac = hmac.digest()
 
-    return ECDHEncrypted(iv, ephemPublicKey, ciphertext, mac)
+    return ECIESEncrypted(iv, ephemPublicKey, ciphertext, mac)
 
-def decryptWithPrivateKey(privateKey: Union[bytes, str], encrypted: ECDHEncrypted) -> str:
+def decryptWithPrivateKey(privateKey: Union[bytes, str], encrypted: ECIESEncrypted) -> str:
     """
     Decrypts encrypted data with privateKey.
     """

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,4 +1,4 @@
-from ain.types import ECDHEncrypted, SetOperation, TransactionBody
+from ain.types import ECIESEncrypted, SetOperation, TransactionBody
 
 """
 The data in this file is for running test ONLY. Do NOT use it for production.
@@ -38,7 +38,7 @@ txDifferent = TransactionBody(
     parent_tx_hash="",
 )
 ephemPrivateKey=bytes.fromhex("51df6a6e250f9cbb083f319104f2ef8f4093b4851a5a46c0cbd6d00a19bf5078")
-encrypted = ECDHEncrypted(
+encrypted = ECIESEncrypted(
     iv=bytes.fromhex("cbf51904342a81d80a767dca8f5d7399"),
     ephemPublicKey=bytes.fromhex("043a25edc1f59d665ded8a875e7a6d4cf31e4fddc97021b576f8389fa920729cc8d6528a07721102cc43496a14da2a4d7907fd32d57058ab6726b2aea617215106"),
     ciphertext=bytes.fromhex("e71bb030fb2956dff3cb89637352f189"),

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,4 +1,4 @@
-from ain.types import SetOperation, TransactionBody
+from ain.types import ECDHEncrypted, SetOperation, TransactionBody
 
 """
 The data in this file is for running test ONLY. Do NOT use it for production.
@@ -36,4 +36,11 @@ txDifferent = TransactionBody(
     nonce=10,
     timestamp=1234,
     parent_tx_hash="",
+)
+ephemPrivateKey=bytes.fromhex("51df6a6e250f9cbb083f319104f2ef8f4093b4851a5a46c0cbd6d00a19bf5078")
+encrypted = ECDHEncrypted(
+    iv=bytes.fromhex("cbf51904342a81d80a767dca8f5d7399"),
+    ephemPublicKey=bytes.fromhex("043a25edc1f59d665ded8a875e7a6d4cf31e4fddc97021b576f8389fa920729cc8d6528a07721102cc43496a14da2a4d7907fd32d57058ab6726b2aea617215106"),
+    ciphertext=bytes.fromhex("e71bb030fb2956dff3cb89637352f189"),
+    mac=bytes.fromhex("53031981f5f6631ddba5ef6f5a050a1dedb4975b2de2ecc1beaf3e3953582d78"),
 )

--- a/tests/test_ain_utils.py
+++ b/tests/test_ain_utils.py
@@ -11,6 +11,7 @@ from .data import (
     correctSignature,
     tx,
     txDifferent,
+    encrypted,
 )
 
 class TestKeccak(TestCase):
@@ -178,8 +179,15 @@ class TestMnemonicToPrivatekey(TestCase):
     def testMnemonicToPrivatekey(self):
         self.assertEqual(mnemonicToPrivatekey(mnemonic), mnemonicPrivateKey)
 
-# TODO(kriii): Add tests after implement `encryptWithPublicKey` and `decryptWithPrivateKey`.
-# class TestEncryption(TestCase):
+class TestEncryption(TestCase):
+    def testEncryptToDecrypt(self):
+        tmpEncrypted = encryptWithPublicKey(pk, message)
+        decrypted = decryptWithPrivateKey(sk, tmpEncrypted)
+        self.assertEqual(message, decrypted)
+
+    def testDecryptEncrypted(self):
+        decrypted = decryptWithPrivateKey(sk, encrypted)
+        self.assertEqual(message, decrypted)
 
 # TODO(kriii): Add tests after implement `encode`.
 # class TestEncode(TestCase):


### PR DESCRIPTION
Add ECDH encrypt/decrypt methods.

I'd got stuck on [this line](https://github.com/ainblockchain/ain-py/blob/feature/ecdh/ain/utils.py#L348). The problem was that `eccrypto` uses the derived key as a shared key. In contrast, some docs and implementations said the derived key is applying some KDF to the concatenation of the ephemeral key and the shared key.
 
`eccrypto` uses `EVP_PKEY_derive` functions from the OpenSSL library, but I couldn't find the description of the default engine's behavior. I tested some combinations of KDF and concatenations, but all failed.