### PR TITLE
Implement V3Keystore

### DIFF
--- a/ain/utils/V3Keystore.py
+++ b/ain/utils/V3Keystore.py
@@ -1,0 +1,294 @@
+import json
+import uuid as UUID
+from types import SimpleNamespace
+from typing import Union, Optional
+from secrets import token_bytes
+from Crypto.Cipher import AES
+from Crypto.Protocol.KDF import PBKDF2, scrypt
+from Crypto.Hash import SHA256
+from Crypto.Util.Padding import pad, unpad
+from ain.utils import privateToAddress, keccak
+
+class Cipherparams:
+    iv: str
+
+class Crypto:
+    ciphertext: str
+    cipherparams: Cipherparams
+    cipher: str
+    kdf: str
+    kdfparams: dict
+    mac: str
+
+class V3KeystoreOptions:
+    salt: Optional[bytes]
+    iv: Optional[bytes]
+    kdf: Optional[str]
+    dklen: Optional[int]
+    n: Optional[int]
+    r: Optional[int]
+    p: Optional[int]
+    c: Optional[int]
+    cipher: Optional[str]
+    uuid: Optional[bytes]
+
+    def __init__(
+        self,
+        salt: bytes = None,
+        iv: bytes = None,
+        kdf: str = None,
+        dklen: int = None,
+        n: int = None,
+        r: int = None,
+        p: int = None,
+        c: int = None,
+        cipher: str = None,
+        uuid: bytes = None,
+    ):
+        if salt is not None:
+            self.salt = salt
+        if iv is not None:
+            self.iv = iv
+        if kdf is not None:
+            self.kdf = kdf
+        if dklen is not None:
+            self.dklen = dklen
+        if n is not None:
+            self.n = n
+        if r is not None:
+            self.r = r
+        if p is not None:
+            self.r = p
+        if c is not None:
+            self.c = c
+        if cipher is not None:
+            self.cipher = cipher
+        if uuid is not None:
+            self.uuid = uuid
+
+class V3Keystore:
+    version: int
+    id: str
+    address: str
+    crypto: Crypto
+
+    def __init__(
+        self,
+        version: int,
+        id: str,
+        address: str,
+        ciphertext: str,
+        iv: str,
+        cipher: str,
+        kdf: str,
+        kdfparams: dict,
+        mac: str
+    ):
+        self.version = version
+        self.id = id
+        self.address = address
+        self.crypto = Crypto()
+        self.crypto.ciphertext = ciphertext
+        self.crypto.cipherparams = Cipherparams()
+        self.crypto.cipherparams.iv = iv
+        self.crypto.cipher = cipher
+        self.crypto.kdf = kdf
+        self.crypto.kdfparams = kdfparams
+        self.crypto.mac = mac
+
+    @classmethod
+    def fromPrivateKey(
+        cls,
+        privateKey: Union[bytes, str],
+        password: str,
+        options: V3KeystoreOptions = V3KeystoreOptions()
+    ):
+        """
+        Converts an account into a V3 Keystore and encrypts it with a password.
+        """
+
+        if type(privateKey) is str:
+            privateKeyBytes = bytes.fromhex(privateKey)
+        elif type(privateKey) is bytes:
+            privateKeyBytes = privateKey
+        else:
+            raise ValueError("Invalid public key type")
+
+        salt = getattr(options, "salt", token_bytes(32))
+        iv = getattr(options, "iv", token_bytes(16))
+        uuid = getattr(options, "uuid", token_bytes(16))
+        dklen = getattr(options, "dklen", 32)
+        kdf = getattr(options, "kdf", "scrypt")
+
+        kdfparams = {
+            "dklen": dklen,
+            "salt": salt.hex(),
+        }
+        if kdf == "scrypt":
+            n = getattr(options, "n", 262144)
+            r = getattr(options, "r", 8)
+            p = getattr(options, "p", 1)
+            kdfparams.update({
+                "n": n,
+                "r": r,
+                "p": p,
+            })
+            derivedKeyTemp = scrypt(
+                password,
+                salt, # type: ignore
+                dklen,
+                N=n,
+                r=r,
+                p=p
+            )
+            if type(derivedKeyTemp) is bytes:
+                derivedKey = derivedKeyTemp
+            else:
+                raise ValueError("scrypt derived multiple keys")
+        elif kdf == "pbkdf2":
+            c = getattr(options, "c", 1000)
+            kdfparams.update({
+                "c": c,
+                "prf": "hmac-sha256",
+            })
+            derivedKey = PBKDF2(
+                password,
+                salt,
+                dklen,
+                count=c,
+                hmac_hash_module=SHA256
+            )
+        else:
+            raise ValueError("Unsupported kdf")
+
+        cipherkey = derivedKey[0:16]
+        padding = False
+        cipher = getattr(options, "cipher", "aes-128-ctr")
+        if cipher == "aes-128-ecb":
+            aescipher = AES.new(cipherkey, AES.MODE_ECB)
+            padding = True
+        elif cipher == "aes-128-cbc" or cipher == "aes128":
+            aescipher = AES.new(cipherkey, AES.MODE_CBC, iv)
+            padding = True
+        elif cipher == "aes-128-cfb":
+            aescipher = AES.new(cipherkey, AES.MODE_CFB, iv, segment_size=128)
+        elif cipher == "aes-128-cfb8":
+            aescipher = AES.new(cipherkey, AES.MODE_CFB, iv)
+        elif cipher == "aes-128-ofb":
+            aescipher = AES.new(cipherkey, AES.MODE_OFB, iv)
+        elif cipher == "aes-128-ctr":
+            aescipher = AES.new(cipherkey, AES.MODE_CTR, nonce=iv[:8], initial_value=iv[8:])
+        else:
+            raise ValueError("Unsupported cipher")
+
+        if padding:
+            ciphertext = aescipher.encrypt(pad(privateKeyBytes, AES.block_size))
+        else:
+            ciphertext = aescipher.encrypt(privateKeyBytes)
+
+        return cls(
+            version=3,
+            id=str(UUID.UUID(bytes=uuid, version=4)),
+            address=privateToAddress(privateKeyBytes).lower().replace("0x",""),
+            ciphertext=ciphertext.hex(),
+            iv=iv.hex(),
+            cipher=cipher,
+            kdf=kdf,
+            kdfparams=kdfparams,
+            mac=keccak(derivedKey[16:32] + ciphertext).hex()
+        )
+
+    @classmethod
+    def fromJSON(cls, v3KeystoreJSON: str):
+        loaded = json.loads(v3KeystoreJSON, object_hook=lambda d: SimpleNamespace(**d))
+        version = int(loaded.version)
+        id = str(loaded.id)
+        address = str(loaded.address)
+        ciphertext = str(loaded.crypto.ciphertext)
+        iv = str(loaded.crypto.cipherparams.iv)
+        cipher = str(loaded.crypto.cipher)
+        kdf = str(loaded.crypto.kdf)
+        kdfparams = dict(loaded.crypto.kdfparams.__dict__)
+        mac = str(loaded.crypto.mac)
+        return cls(
+            version,
+            id,
+            address,
+            ciphertext,
+            iv,
+            cipher,
+            kdf,
+            kdfparams,
+            mac
+        )
+
+    def toPrivateKey(self, password: str) -> bytes:
+        """
+        Returns a private key from a V3 Keystore.
+        """
+
+        kdfparams = self.crypto.kdfparams
+        salt = bytes.fromhex(kdfparams["salt"])
+        dklen = kdfparams["dklen"]
+        if self.crypto.kdf == "scrypt":
+            derivedKeyTemp = scrypt(
+                password,
+                salt, # type: ignore
+                dklen,
+                N=kdfparams["n"],
+                r=kdfparams["r"],
+                p=kdfparams["p"]
+            )
+            if type(derivedKeyTemp) is bytes:
+                derivedKey = derivedKeyTemp
+            else:
+                raise ValueError("scrypt derived multiple keys")
+        elif self.crypto.kdf == "pbkdf2":
+            derivedKey = PBKDF2(
+                password,
+                salt,
+                dklen,
+                count=kdfparams["c"],
+                hmac_hash_module=SHA256
+            )
+        else:
+            raise ValueError("Unsupported kdf")
+
+        ciphertext = bytes.fromhex(self.crypto.ciphertext)
+        mac = keccak(derivedKey[16:32] + ciphertext).hex()
+        if mac != self.crypto.mac:
+            raise ValueError("Key derivation failed - possibly wrong password")
+            
+        cipherkey = derivedKey[0:16]
+        padding = False
+        cipher = self.crypto.cipher
+        iv = bytes.fromhex(self.crypto.cipherparams.iv)
+        if cipher == "aes-128-ecb":
+            aescipher = AES.new(cipherkey, AES.MODE_ECB)
+            padding = True
+        elif cipher == "aes-128-cbc" or cipher == "aes128":
+            aescipher = AES.new(cipherkey, AES.MODE_CBC, iv)
+            padding = True
+        elif cipher == "aes-128-cfb":
+            aescipher = AES.new(cipherkey, AES.MODE_CFB, iv, segment_size=128)
+        elif cipher == "aes-128-cfb8":
+            aescipher = AES.new(cipherkey, AES.MODE_CFB, iv)
+        elif cipher == "aes-128-ofb":
+            aescipher = AES.new(cipherkey, AES.MODE_OFB, iv)
+        elif cipher == "aes-128-ctr":
+            aescipher = AES.new(cipherkey, AES.MODE_CTR, nonce=iv[:8], initial_value=iv[8:])
+        else:
+            raise ValueError("Unsupported cipher")
+
+        if padding:
+            privateKeyBytes = unpad(aescipher.decrypt(ciphertext), AES.block_size)
+        else:
+            privateKeyBytes = aescipher.decrypt(ciphertext)
+        return privateKeyBytes
+
+    def __str__(self):
+        return json.dumps(
+            self.__dict__,
+            default=lambda o: o.__dict__,
+            separators=(",", ":")
+        )

--- a/ain/utils/V3Keystore.py
+++ b/ain/utils/V3Keystore.py
@@ -146,7 +146,7 @@ class V3Keystore:
             else:
                 raise ValueError("scrypt derived multiple keys")
         elif kdf == "pbkdf2":
-            c = getattr(options, "c", 1000)
+            c = getattr(options, "c", 262144)
             kdfparams.update({
                 "c": c,
                 "prf": "hmac-sha256",

--- a/ain/utils/__init__.py
+++ b/ain/utils/__init__.py
@@ -3,7 +3,6 @@ import json
 import time
 from typing import Any, Union
 from secrets import token_bytes
-from Crypto import Cipher
 from Crypto.Cipher import AES
 from Crypto.Hash import keccak as _keccak
 from Crypto.Hash import HMAC, SHA256, SHA512
@@ -389,11 +388,3 @@ def decryptWithPrivateKey(privateKey: Union[bytes, str], encrypted: ECIESEncrypt
     aes = AES.new(encKey, AES.MODE_CBC, iv=encrypted.iv)
     plaintext = unpad(aes.decrypt(encrypted.ciphertext), 16)
     return plaintext.decode("utf-8")
-
-# TODO(kriii): implement this function.
-def privateToV3Keystore():
-    pass
-
-# TODO(kriii): implement this function.
-def v3KeystoreToPrivate():
-    pass

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -15,6 +15,7 @@ from ain.utils import (
     ecRecoverPub,
     ecVerifySig,
 )
+from ain.utils.V3Keystore import V3Keystore, V3KeystoreOptions
 
 if TYPE_CHECKING:
     from ain.ain import Ain
@@ -216,16 +217,20 @@ class Wallet:
     def verifySignature(self, data: Any, signature: str, address: str) -> bool:
         return ecVerifySig(data, signature, address, self.chainId)
 
-    # TODO(kriii): implement this function.
-    def toV3Keystore(self):
+    def toV3Keystore(self, password: str, options: V3KeystoreOptions) -> List[V3Keystore]:
         """
         Save the accounts in the wallet as V3 Keystores, locking them with the password.
         """
-        pass
+        ret = []
+        for address in self.accounts:
+            ret.append(self.accountToV3Keystore(address, password, options))
+        return ret
     
-    # TODO(kriii): implement this function.
-    def accountToV3Keystore(self):
+    def accountToV3Keystore(self, address: str, password: str, options: V3KeystoreOptions) -> V3Keystore:
         """
         Converts an account into a V3 Keystore and encrypts it with a password.
         """
-        pass
+        if not self.isAdded(address):
+            raise ValueError("No such address exists in the wallet")
+        privateKey = self.accounts[address].private_key
+        return V3Keystore.fromPrivateKey(privateKey, password, options)

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,4 +1,5 @@
 from ain.types import ECIESEncrypted, SetOperation, TransactionBody
+from ain.utils import V3Keystore
 
 """
 The data in this file is for running test ONLY. Do NOT use it for production.
@@ -37,7 +38,23 @@ txDifferent = TransactionBody(
     timestamp=1234,
     parent_tx_hash="",
 )
-ephemPrivateKey=bytes.fromhex("51df6a6e250f9cbb083f319104f2ef8f4093b4851a5a46c0cbd6d00a19bf5078")
+v3KeystorePassword = "password"
+v3KeystoreKDFList = ["scrypt", "pbkdf2"]
+v3KeystoreCipherList = ["aes-128-ecb", "aes-128-cbc", "aes128", "aes-128-cfb", "aes-128-cfb8", "aes-128-ofb", "aes-128-ctr"]
+v3KeystoreJSONList = [
+    '{"version":3,"id":"036b69a2-e265-4629-8228-9fa50e6cfc83","address":"cacd898dbaedbd9037acd25b82417587e972838d","crypto":{"ciphertext":"d5f30deaaef26536cfa032847ad85b09c7a4e196ef63d958c5f07c2cd492427b61b1db392e34b6a48323df4c63de510b","cipherparams":{"iv":"7f0b94879355a1ad5b0fe2f01505d6a6"},"cipher":"aes-128-cbc","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"869052b90a88af78d8957d857bce751dc497843a5510ecc82060e7c9df96257e","n":262144,"r":8,"p":1},"mac":"54769926fa51577e2f70f30b9665a07bbcf049c0c2d46509c976d97d408e3795"}}',
+    '{"version":3,"id":"6cada97a-4b22-4846-a272-89035c027c4f","address":"cacd898dbaedbd9037acd25b82417587e972838d","crypto":{"ciphertext":"03067fe2bab917fdf54c49f4c155c2ecb21ff27c7883cf88c637132fa43256c528b3f80a8548147f998c210ed483f7bf","cipherparams":{"iv":"4f289baf793101fd10779aa696bb7597"},"cipher":"aes128","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"25661c1cd634d8ae925232763c7d8b3ac82de2729a6570083780ee0c1c59c44d","n":262144,"r":8,"p":1},"mac":"a04a7145044e175b4c5455a8d26b729e4bfe94505dad3d43216ec35a7ac4abbb"}}',
+    '{"version":3,"id":"68b26290-dad4-4316-8aa4-f8646c48e95a","address":"cacd898dbaedbd9037acd25b82417587e972838d","crypto":{"ciphertext":"114bfe8830db8ac40f452fcfc1c258a93dc49db0b10ba8bbd1fc2b9f3e497a25","cipherparams":{"iv":"01f7bad750cc87c2caab2c349b7522fc"},"cipher":"aes-128-cfb","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"81754707b6bf4c353835cba51aacebed90575f8d166d368d4b544f2585fad433","n":262144,"r":8,"p":1},"mac":"3f263fb59cc607c1523efb005bfef096c053a0b0eb3a219d3215477c68206518"}}',
+    '{"version":3,"id":"d89885da-8706-455e-ac58-8c0d59532294","address":"cacd898dbaedbd9037acd25b82417587e972838d","crypto":{"ciphertext":"5e60a23391eeb56b0013a2b3b0dbef67afaf3edb67886855ec6ae623df497312","cipherparams":{"iv":"7ba8e4e0a265236ba34c0c1280e1b8fc"},"cipher":"aes-128-cfb8","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"731a885adad7157c59c30442f9b401b38462ced988f68204b95977a19d9e33cc","n":262144,"r":8,"p":1},"mac":"5fd8e1538d5273ec4941c71a2d7560f2f144f9f7daf5324d2b1ae906da0da373"}}',
+    '{"version":3,"id":"930f508f-ac94-4aee-ae1e-e3f7770c4d19","address":"cacd898dbaedbd9037acd25b82417587e972838d","crypto":{"ciphertext":"14cc2bb2c0c6d66719898745a7e38cb04135f4fc4d7230431fbaf9486f7beff8","cipherparams":{"iv":"06b87f85e1322240b4cbf5706892324c"},"cipher":"aes-128-ofb","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"31fbaa4abd3d56d3f0d817d676be72023a369237af9aa9171344fc3f3506e97f","n":262144,"r":8,"p":1},"mac":"5700a527f864d33bbba505506db45d697e7ad2033f6015d9718f58a4a55d1c77"}}',
+    '{"version":3,"id":"7fc2b69c-5589-4e3d-8b00-005116d0313f","address":"cacd898dbaedbd9037acd25b82417587e972838d","crypto":{"ciphertext":"74633f0c4c573a732b779df0f26ef7b6f6b1d9a80e259f4ff2a6d4d89ba38dbb","cipherparams":{"iv":"cb02dc99e568473ff970ed4fe29c9831"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"16ae5fb31bb38f0d19bd2099d4c3fc0580f8bfe5b9e77f63ec7ebd5642fa6be7","n":262144,"r":8,"p":1},"mac":"faf27bebb19b3ec02ec199181573e8995da8fec97101969e51d6ae2e632d2be2"}}',
+]
+v3KeystoreFixedUUID = bytes.fromhex("5a548cede1e3f133f2d11b1ef141ef6c")
+v3KeystoreFixedIV = bytes.fromhex("4b45d276487b197fafaa81b7037a6268")
+v3KeystoreFixedSalt = bytes.fromhex("0445842268ad439d95bc3b44e2cc460333b3ef37f7de775e1e5cad702eebd83c")
+v3KeystoreFixedJSON = '{"version":3,"id":"5a548ced-e1e3-4133-b2d1-1b1ef141ef6c","address":"cacd898dbaedbd9037acd25b82417587e972838d","crypto":{"ciphertext":"116c8f26da9f4a5fad7e0f1e039273dbfc3bdfa0adc9342af4cd3bd8a22bcc3d","cipherparams":{"iv":"4b45d276487b197fafaa81b7037a6268"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"0445842268ad439d95bc3b44e2cc460333b3ef37f7de775e1e5cad702eebd83c","n":262144,"r":8,"p":1},"mac":"7cdddc92fe290b26f08ef7031fb8fade154774e4a5ea799d145b158419159add"}}'
+
+ephemPrivateKey = bytes.fromhex("51df6a6e250f9cbb083f319104f2ef8f4093b4851a5a46c0cbd6d00a19bf5078")
 encrypted = ECIESEncrypted(
     iv=bytes.fromhex("cbf51904342a81d80a767dca8f5d7399"),
     ephemPublicKey=bytes.fromhex("043a25edc1f59d665ded8a875e7a6d4cf31e4fddc97021b576f8389fa920729cc8d6528a07721102cc43496a14da2a4d7907fd32d57058ab6726b2aea617215106"),

--- a/tests/test_ain_utils.py
+++ b/tests/test_ain_utils.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from ain.utils import *
+from ain.utils.V3Keystore import *
 from .data import (
     address,
     pk,
@@ -11,6 +12,14 @@ from .data import (
     correctSignature,
     tx,
     txDifferent,
+    v3KeystoreKDFList,
+    v3KeystoreCipherList,
+    v3KeystorePassword,
+    v3KeystoreJSONList,
+    v3KeystoreFixedUUID,
+    v3KeystoreFixedIV,
+    v3KeystoreFixedSalt,
+    v3KeystoreFixedJSON,
     encrypted,
 )
 
@@ -112,9 +121,33 @@ class TestPrivateToAddress(TestCase):
     def testPrivateToAddress(self):
         self.assertEqual(privateToAddress(sk), address)
 
-# TODO(kriii): Add tests after implement `V3Keystore` methods.
-# class TestV3KeyStore(TestCase):
+class TestV3KeyStore(TestCase):
+    def testV3KeyStore(self):
+        v3keystore = V3Keystore.fromPrivateKey(sk, v3KeystorePassword)
+        self.assertEqual(v3keystore.toPrivateKey(v3KeystorePassword), sk)
+    
+    def testV3KeyStoreKDF(self):
+        for kdf in v3KeystoreKDFList:
+            v3keystore = V3Keystore.fromPrivateKey(sk, v3KeystorePassword, V3KeystoreOptions(kdf=kdf))
+            self.assertEqual(v3keystore.toPrivateKey(v3KeystorePassword), sk, msg=json)
 
+    def testV3KeyStoreCipher(self):
+        for cipher in v3KeystoreCipherList:
+            v3keystore = V3Keystore.fromPrivateKey(sk, v3KeystorePassword, V3KeystoreOptions(cipher=cipher))
+            self.assertEqual(v3keystore.toPrivateKey(v3KeystorePassword), sk, msg=json)
+
+    def testV3KeyStoreFromJSON(self):
+        for json in v3KeystoreJSONList:
+            v3keystoreFromJSON = V3Keystore.fromJSON(json)
+            self.assertEqual(v3keystoreFromJSON.toPrivateKey(v3KeystorePassword), sk, msg=json)
+
+    def testV3KeyStoreFromFixed(self):
+        v3keystore = V3Keystore.fromPrivateKey(
+            sk, v3KeystorePassword,
+            V3KeystoreOptions(uuid=v3KeystoreFixedUUID, iv=v3KeystoreFixedIV, salt=v3KeystoreFixedSalt)
+        )
+        self.assertEqual(str(v3keystore), v3KeystoreFixedJSON)
+        
 class TestToBytes(TestCase):
     def testToBytes(self):
         # bytes


### PR DESCRIPTION
Change
- Migrated ain.utils as subpackage.
- Implemented V3Keystore.

Notes
- `pbkdf2` in ain-js doesn't work.
- It seems ain-js uses [browserify-cipher](https://www.npmjs.com/package/browserify-cipher) so I ported every `aes-128-*`, but not `des-*`. I don't think anybody uses `des`.
- `cfb` mode of PyCryptodome must need `segment_size` is multiple of 8, so doesn't support `aes-128-cfb1`.
