### PR TITLE
Add package version specify & Deprecate py36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-typing-extensions
-pycryptodome
-coincurve
-aiohttp[speedups]
-jsonrpcclient
-mnemonic
-bip32
+typing-extensions==4.7.1
+pycryptodome==3.18.0
+coincurve==18.0.0
+aiohttp[speedups]==3.8.5
+jsonrpcclient==4.0.3
+mnemonic==0.20
+bip32==3.4
 snapshottest
 sphinx-rtd-theme
 readthedocs-sphinx-ext

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,13 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 requirements = [
-    "typing-extensions",
-    "pycryptodome",
-    "coincurve",
-    "aiohttp[speedups]",
-    "jsonrpcclient",
-    "mnemonic",
-    "bip32",
-    "snapshottest",
+    "typing-extensions==4.7.1",
+    "pycryptodome==3.18.0",
+    "coincurve==18.0.0",
+    "aiohttp[speedups]==3.8.5",
+    "jsonrpcclient==4.0.3",
+    "mnemonic==0.20",
+    "bip32==3.4",
 ]
 
 test_requirements = []
@@ -20,14 +19,13 @@ test_requirements = []
 setup(
     author="AIN Dev Team",
     author_email="dev@ainetwork.ai",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Changes

- Add package version specify
- Deprecate py36 (It's incompatible with some packages and too old.)