### PR TITLE
Add dryrun transaction API

### DIFF
--- a/ain/ain.py
+++ b/ain/ain.py
@@ -171,11 +171,12 @@ class Ain:
             "ain_validateAppName", {"app_name": appName}
         )
 
-    async def sendTransaction(self, transactionObject: TransactionInput) -> Any:
+    async def sendTransaction(self, transactionObject: TransactionInput, isDryrun = False) -> Any:
         """Signs and sends the transaction to the network.
 
         Args:
             transactionObject (TransactionInput): The transaction.
+            isDryrun (bool): Dryrun option.
 
         Returns:
             The transaction result.
@@ -184,20 +185,21 @@ class Ain:
         signature = self.wallet.signTransaction(
             txBody, getattr(transactionObject, "address", None)
         )
-        return await self.sendSignedTransaction(signature, txBody)
+        return await self.sendSignedTransaction(signature, txBody, isDryrun)
 
-    async def sendSignedTransaction(self, signature: str, txBody: TransactionBody) -> Any:
+    async def sendSignedTransaction(self, signature: str, txBody: TransactionBody, isDryrun = False) -> Any:
         """Sends a signed transaction to the network.
 
         Args:
             signature (str): The signature of the transaction.
             txBody (TransactionBody): The transaction body.
+            isDryrun (bool): Dryrun option.
 
         Returns:
             The transaction result.
         """
-        return await self.provider.send(
-            "ain_sendSignedTransaction", {"signature": signature, "tx_body": txBody}
+        method = "ain_sendSignedTransactionDryrun" if isDryrun == True else "ain_sendSignedTransaction"
+        return await self.provider.send(method, {"signature": signature, "tx_body": txBody}
         )
 
     async def sendTransactionBatch(self, transactionObjects: List[TransactionInput]) -> List[Any]:

--- a/ain/db/ref.py
+++ b/ain/db/ref.py
@@ -160,12 +160,13 @@ class Reference:
         req = {"type": "GET", "op_list": extendedGets}
         return await self._ain.provider.send("ain_get", req)
 
-    async def deleteValue(self, transactionInput: ValueOnlyTransactionInput = None) -> Any:
+    async def deleteValue(self, transactionInput: ValueOnlyTransactionInput = None, isDryrun = False) -> Any:
         """Deletes the value.
 
         Args:
             transactionInput (ValueOnlyTransactionInput): The transaction input object.
                 Any value given will be overwritten with null.
+            isDryrun (bool): Dryrun option.
 
         Returns:
             The result of the transaction.
@@ -184,14 +185,16 @@ class Reference:
             TransactionInput(
                 operation=operation,
                 parent_tx_hash=getattr(txInput, "parent_tx_hash", None),
-            )
+            ),
+            isDryrun
         )
 
-    async def setFunction(self, transactionInput: ValueOnlyTransactionInput) -> Any:
+    async def setFunction(self, transactionInput: ValueOnlyTransactionInput, isDryrun = False) -> Any:
         """Sets the function config.
 
         Args:
             transactionInput (ValueOnlyTransactionInput): The transaction input object.
+            isDryrun (bool): Dryrun option.
 
         Returns:
             The result of the transaction.
@@ -203,14 +206,16 @@ class Reference:
                 ref,
                 "SET_FUNCTION",
                 self._isGlobal
-            )
+            ),
+            isDryrun
         )
 
-    async def setOwner(self, transactionInput: ValueOnlyTransactionInput) -> Any:
+    async def setOwner(self, transactionInput: ValueOnlyTransactionInput, isDryrun = False) -> Any:
         """Sets the owner rule.
 
         Args:
             transactionInput (ValueOnlyTransactionInput): The transaction input object.
+            isDryrun (bool): Dryrun option.
             
         Returns:
             The result of the transaction.
@@ -222,14 +227,16 @@ class Reference:
                 ref,
                 "SET_OWNER",
                 self._isGlobal
-            )
+            ),
+            isDryrun
         )
 
-    async def setRule(self, transactionInput: ValueOnlyTransactionInput) -> Any:
+    async def setRule(self, transactionInput: ValueOnlyTransactionInput, isDryrun = False) -> Any:
         """Sets the write rule.
 
         Args:
             transactionInput (ValueOnlyTransactionInput): The transaction input object.
+            isDryrun (bool): Dryrun option.
             
         Returns:
             The result of the transaction.
@@ -241,14 +248,16 @@ class Reference:
                 ref,
                 "SET_RULE",
                 self._isGlobal
-            )
+            ),
+            isDryrun
         )
 
-    async def setValue(self, transactionInput: ValueOnlyTransactionInput) -> Any:
+    async def setValue(self, transactionInput: ValueOnlyTransactionInput, isDryrun = False) -> Any:
         """Sets the value.
 
         Args:
             transactionInput (ValueOnlyTransactionInput): The transaction input object.
+            isDryrun (bool): Dryrun option.
             
         Returns:
             The result of the transaction.
@@ -260,14 +269,16 @@ class Reference:
                 ref,
                 "SET_VALUE",
                 self._isGlobal
-            )
+            ),
+            isDryrun
         )
 
-    async def incrementValue(self, transactionInput: ValueOnlyTransactionInput) -> Any:
+    async def incrementValue(self, transactionInput: ValueOnlyTransactionInput, isDryrun = False) -> Any:
         """Increments the value.
 
         Args:
             transactionInput (ValueOnlyTransactionInput): The transaction input object.
+            isDryrun (bool): Dryrun option.
             
         Returns:
             The result of the transaction.
@@ -279,14 +290,16 @@ class Reference:
                 ref,
                 "INC_VALUE",
                 self._isGlobal
-            )
+            ),
+            isDryrun
         )
 
-    async def decrementValue(self, transactionInput: ValueOnlyTransactionInput) -> Any:
+    async def decrementValue(self, transactionInput: ValueOnlyTransactionInput, isDryrun = False) -> Any:
         """Decrements the value.
         
         Args:
             transactionInput (ValueOnlyTransactionInput): The transaction input object.
+            isDryrun (bool): Dryrun option.
             
         Returns:
             The result of the transaction.
@@ -298,14 +311,16 @@ class Reference:
                 ref,
                 "DEC_VALUE",
                 self._isGlobal
-            )
+            ),
+            isDryrun
         )
 
-    async def set(self, transactionInput: SetMultiTransactionInput) -> Any:
+    async def set(self, transactionInput: SetMultiTransactionInput, isDryrun = False) -> Any:
         """Processes the multiple set operations.
         
         Args:
             transactionInput (SetMultiTransactionInput): The transaction input object.
+            isDryrun (bool): Dryrun option.
             
         Returns:
             The result of the transaction.
@@ -314,7 +329,8 @@ class Reference:
             Reference.extendSetMultiTransactionInput(
                 transactionInput,
                 self._path,
-            )
+            ),
+            isDryrun
         )
 
     async def evalRule(self, params: EvalRuleInput) -> Any:

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -224,7 +224,7 @@ class Wallet:
             addr = toChecksumAddress(address)
         return await self.ain.db.ref(f"/accounts/{addr}/balance").getValue()
 
-    async def transfer(self, toAddress: str, value: int, fromAddress: str = None, nonce: int = None, gas_price: int = None):
+    async def transfer(self, toAddress: str, value: int, fromAddress: str = None, nonce: int = None, gas_price: int = None, isDryrun = False):
         """Sends a transfer transaction to the network.
 
         Args:
@@ -236,6 +236,7 @@ class Wallet:
                 Defaults to `None`.
             gas_price (int, Optional): The gas price of the transfer transaction.
                 Defaults to `None`.
+            isDryrun (bool): Dryrun option.
         
         Returns:
             The transaction result.
@@ -250,7 +251,8 @@ class Wallet:
                 value=value,
                 nonce=nonce,
                 gas_price=gas_price,
-            )
+            ),
+            isDryrun
         )
 
     def sign(self, data: str, address: str = None) -> str:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     description="AI Network Client Library for Python3",
     install_requires=requirements,

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -150,6 +150,15 @@ class TestWallet(TestCase):
         self.assertGreaterEqual(await ain.wallet.getBalance(), 0)
 
     @asyncTest
+    async def testTransferIsDryrunTrue(self):
+        ain = Ain(testNode)
+        ain.wallet.addAndSetDefaultAccount(accountSk)
+        balanceBefore = await ain.wallet.getBalance()
+        await ain.wallet.transfer(transferAddress, 100, nonce=-1, isDryrun=True)  # isDryrun = True
+        balanceAfter = await ain.wallet.getBalance()
+        self.assertEqual(balanceBefore, balanceAfter)  # NOT changed!
+
+    @asyncTest
     async def testTransfer(self):
         ain = Ain(testNode)
         ain.wallet.addAndSetDefaultAccount(accountSk)
@@ -264,6 +273,32 @@ class TestCore(TestCase):
         self.assertTrue(raised)
 
     @asyncTest
+    async def test00SendTransactionIsDryrunTrue(self):
+        op = SetOperation(
+            type="SET_OWNER",
+            ref=f"/apps/test{PY_VERSION}",
+            value={
+                ".owner": {
+                    "owners": {
+                        "*": {
+                            "write_owner": True,
+                            "write_rule": True,
+                            "write_function": True,
+                            "branch_owner": True
+                        }
+                    }
+                }
+            }
+        )
+        res = await self.ain.sendTransaction(TransactionInput(operation=op), True)  # isDryrun = True
+        self.assertEqual(res["result"]["code"], 0)
+        targetTxHash = res["tx_hash"]
+        self.assertTrue(TX_PATTERN.fullmatch(targetTxHash) is not None)
+
+        tx = await self.ain.getTransaction(targetTxHash)
+        self.assertIsNone(tx)  # should be None
+
+    @asyncTest
     async def test00SendTransaction(self):
         op = SetOperation(
             type="SET_OWNER",
@@ -288,6 +323,40 @@ class TestCore(TestCase):
 
         tx = await self.ain.getTransaction(targetTxHash)
         self.assertDictEqual(tx["transaction"]["tx_body"]["operation"], op.__dict__)
+
+    @asyncTest
+    async def test00SendSignedTransactionIsDryrunTrue(self):
+        tx = TransactionBody(
+            nonce=-1,
+            gas_price=500,
+            timestamp=getTimestamp(),
+            operation=SetOperation(
+                type="SET_OWNER",
+                ref=f"/apps/{APP_NAME}{PY_VERSION}",
+                value={
+                    ".owner": {
+                        "owners": {
+                            "*": {
+                                "write_owner": True,
+                                "write_rule": True,
+                                "write_function": True,
+                                "branch_owner": True
+                            }
+                        }
+                    }
+                }
+            )
+        )
+
+        sig = self.ain.wallet.signTransaction(tx)
+        res = await self.ain.sendSignedTransaction(sig, tx, True)  # isDryrun = True
+        targetTxHash = res["tx_hash"]
+        self.assertFalse("code" in res)
+        self.assertTrue(TX_PATTERN.fullmatch(targetTxHash) is not None)
+        self.assertEqual(res["result"]["code"], 0)
+
+        tx = await self.ain.getTransaction(targetTxHash)
+        self.assertIsNone(tx)  # should be None
 
     @asyncTest
     async def test00SendSignedTransaction(self):
@@ -489,6 +558,44 @@ class TestDatabase(SnapshotTestCase):
         self.assertEqual(self.ain.db.ref(self.allowedPath).path, "/" + self.allowedPath)
     
     @asyncTest
+    async def test00SetOwnerIsDryrunTrue(self):
+        res = await self.ain.db.ref(self.allowedPath).setOwner(ValueOnlyTransactionInput(
+            value={
+                ".owner": {
+                    "owners": {
+                        "*": {
+                            "write_owner": True,
+                            "write_rule": True,
+                            "write_function": True,
+                            "branch_owner": True
+                        }
+                    }
+                }
+            }
+        ),
+        True)
+        self.assertEqual(res["result"]["code"], 0)
+        self.assertEqual(res["result"]["is_dryrun"], True)
+
+        fail = await self.ain.db.ref("/consensus").setOwner(ValueOnlyTransactionInput(
+            value={
+                ".owner": {
+                    "owners": {
+                        "*": {
+                            "write_owner": True,
+                            "write_rule": True,
+                            "write_function": True,
+                            "branch_owner": True
+                        }
+                    }
+                }
+            }
+        ),
+        True)
+        self.assertEqual(fail["result"]["code"], 12501)
+        self.assertEqual(fail["result"]["is_dryrun"], True)
+
+    @asyncTest
     async def test00SetOwner(self):
         res = await self.ain.db.ref(self.allowedPath).setOwner(ValueOnlyTransactionInput(
             value={
@@ -523,6 +630,24 @@ class TestDatabase(SnapshotTestCase):
         self.assertEqual(fail["result"]["code"], 12501)
 
     @asyncTest
+    async def test00SetRuleIsDryrunTrue(self):
+        res = await self.ain.db.ref(self.allowedPath).setRule(ValueOnlyTransactionInput(
+            value={ ".rule": { "write": "true" } }
+        ),
+        True)
+        self.assertEqual(res["result"]["code"], 0)
+        self.assertEqual(res["result"]["is_dryrun"], True)
+
+    @asyncTest
+    async def test00SetRuleIsDryrunTrue(self):
+        res = await self.ain.db.ref(self.allowedPath).setRule(ValueOnlyTransactionInput(
+            value={ ".rule": { "write": "true" } }
+        ),
+        True)
+        self.assertEqual(res["result"]["code"], 0)
+        self.assertEqual(res["result"]["is_dryrun"], True)
+
+    @asyncTest
     async def test00SetRule(self):
         res = await self.ain.db.ref(self.allowedPath).setRule(ValueOnlyTransactionInput(
             value={ ".rule": { "write": "true" } }
@@ -530,11 +655,37 @@ class TestDatabase(SnapshotTestCase):
         self.assertEqual(res["result"]["code"], 0)
 
     @asyncTest
+    async def test00SetValueIsDryrunTrue(self):
+        res = await self.ain.db.ref(f"{self.allowedPath}/username").setValue(ValueOnlyTransactionInput(
+            value="test_user"
+        ),
+        True)
+        self.assertEqual(res["result"]["code"], 0)
+        self.assertEqual(res["result"]["is_dryrun"], True)
+
+    @asyncTest
     async def test00SetValue(self):
         res = await self.ain.db.ref(f"{self.allowedPath}/username").setValue(ValueOnlyTransactionInput(
             value="test_user"
         ))
         self.assertEqual(res["result"]["code"], 0)
+
+    @asyncTest
+    async def test00SetFunctionIsDryrunTrue(self):
+        res = await self.ain.db.ref(self.allowedPath).setFunction(ValueOnlyTransactionInput(
+            value={
+                ".function": {
+                    "0xFUNCTION_HASH": {
+                        "function_url": "https://events.ainetwork.ai/trigger",
+                        "function_id": "0xFUNCTION_HASH",
+                        "function_type": "REST"
+                    }
+                }
+            }
+        ),
+        True)
+        self.assertEqual(res["result"]["code"], 0)
+        self.assertEqual(res["result"]["is_dryrun"], True)
 
     @asyncTest
     async def test00SetFunction(self):
@@ -550,6 +701,37 @@ class TestDatabase(SnapshotTestCase):
             }
         ))
         self.assertEqual(res["result"]["code"], 0)
+
+    @asyncTest
+    async def test00SetIsDryrunTrue(self):
+        res = await self.ain.db.ref(self.allowedPath).set(SetMultiTransactionInput(
+            op_list=[
+                SetOperation(
+                    type="SET_RULE",
+                    ref="can/write/",
+                    value={ ".rule": { "write": "true" } }
+                ),
+                SetOperation(
+                    type="SET_RULE",
+                    ref="cannot/write",
+                    value={ ".rule": { "write": "false" } }
+                ),
+                SetOperation(
+                    type="INC_VALUE",
+                    ref="can/write/",
+                    value=5
+                ),
+                SetOperation(
+                    type="DEC_VALUE",
+                    ref="can/write",
+                    value=10
+                )
+            ],
+            nonce=-1
+        ),
+        True)
+        self.assertEqual(len(res["result"]["result_list"].keys()), 4)
+        self.assertEqual(res["result"]["is_dryrun"], True)
 
     @asyncTest
     async def test00Set(self):
@@ -632,6 +814,12 @@ class TestDatabase(SnapshotTestCase):
         self.matchSnapshot(await self.ain.db.ref().getValue(self.allowedPath, GetOptions(include_tree_info=True)))
         getWithVersion = await self.ain.db.ref().getValue(self.allowedPath, GetOptions(include_version=True))
         self.assertTrue("#version" in getWithVersion)
+
+    @asyncTest
+    async def test02DeleteValueIsDryrunTrue(self):
+        res = await self.ain.db.ref(f"{self.allowedPath}/can/write").deleteValue(isDryrun=True)
+        self.assertEqual(res["result"]["code"], 0)
+        self.assertEqual(res["result"]["is_dryrun"], True)
 
     @asyncTest
     async def test02DeleteValue(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Change summary:
- Add isDryrun = true option to blockchain write methods
- Add python v3.11 to the test version list

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1182