### PR TITLE
Add Signer / DefaultSigner classes

### DIFF
--- a/ain/db/ref.py
+++ b/ain/db/ref.py
@@ -344,7 +344,7 @@ class Reference:
             `True`, if the params satisfy the write rule,
             `False,` if not.
         """
-        address = self._ain.wallet.getImpliedAddress(getattr(params, "address", None))
+        address = self._ain.signer.getAddress(getattr(params, "address", None))
         req = {
             "address": address,
             "ref": Reference.extendPath(self._path, getattr(params, "ref", None)),
@@ -363,7 +363,7 @@ class Reference:
         Returns:
             The owner evaluation result.
         """
-        address = self._ain.wallet.getImpliedAddress(getattr(params, "address", None))
+        address = self._ain.signer.getAddress(getattr(params, "address", None))
         req = {
             "address": address,
             "ref": Reference.extendPath(self._path, getattr(params, "ref", None)),

--- a/ain/signer/__init__.py
+++ b/ain/signer/__init__.py
@@ -35,7 +35,7 @@ class Signer(metaclass = ABCMeta):
 
 class DefaultSigner(Signer):
     """The default concrete class of Signer abstract class implemented using Wallet class.
-       When ain class is initialized, DefaultSigner is set as its signer.
+       When Ain class is initialized, DefaultSigner is set as its signer.
 
     Args:
         wallet (Wallet): The wallet to initialize with.

--- a/ain/signer/__init__.py
+++ b/ain/signer/__init__.py
@@ -25,6 +25,7 @@ class Signer(metaclass = ABCMeta):
            If the address is not given, the default address of the signer is used.
 
         Args:
+            message (Any): The message to sign.
             address (str, Optional): The address of the account to sign the message with.
 
         Returns:
@@ -63,6 +64,7 @@ class DefaultSigner(Signer):
            If the address is not given, the default address of the wallet is used.
 
         Args:
+            message (Any): The message to sign.
             address (str, Optional): The address of the account to sign the message with.
 
         Returns:

--- a/ain/signer/__init__.py
+++ b/ain/signer/__init__.py
@@ -1,0 +1,74 @@
+from abc import *
+from typing import Any
+from ain.wallet import Wallet
+
+class Signer(metaclass = ABCMeta):
+    """An abstract class for signing messages and transactions.
+    """
+    
+    @abstractmethod
+    def getAddress(self, address: str = None) -> str:
+        """Return the checksum address to sign messages with.
+           If the address is not given, the default address of the signer is used.
+
+        Args:
+            address (str, Optional): The address of the account to sign messages with.
+
+        Returns:
+            str: The checksum address.
+        """
+        pass
+
+    @abstractmethod
+    async def signMessage(self, message: Any, address: str = None) -> str:
+        """Signs a message with the private key of the given address.
+           If the address is not given, the default address of the signer is used.
+
+        Args:
+            address (str, Optional): The address of the account to sign the message with.
+
+        Returns:
+            str: The signature of the message.
+        """
+        pass
+
+
+class DefaultSigner(Signer):
+    """The default concrete class of Signer abstract class implemented using Wallet class.
+       When ain class is initialized, DefaultSigner is set as its signer.
+
+    Args:
+        wallet (Wallet): The wallet to initialize with.
+    """
+    
+    wallet: Wallet
+
+    def __init__(self, wallet: Wallet):
+        self.wallet = wallet
+
+    def getAddress(self, address: str = None) -> str:
+        """Return the checksum address to sign messages with.
+           If the address is not given, the default address of the wallet is used.
+
+        Args:
+            address (str, Optional): The address of the account to sign messages with.
+
+        Returns:
+            str: The checksum address.
+        """
+        return self.wallet.getImpliedAddress(address)
+
+    async def signMessage(self, message: Any, address: str = None) -> str:
+        """Signs a message with the private key of the given address.
+           If the address is not given, the default address of the wallet is used.
+
+        Args:
+            address (str, Optional): The address of the account to sign the message with.
+
+        Returns:
+            str: The signature of the message.
+        """
+        if type(message) is str:
+            return self.wallet.sign(message, address)
+        else:
+            return self.wallet.signTransaction(message, address)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+no_implicit_optional = False
+


### PR DESCRIPTION
Change summary:
- Add Signer abstract class and DefaultSigner concrete class
- Use signer's methods instead of signTransaction and getImpliedAddress in Ain / Reference classes
- Add mypy.ini config file

Related PRs:
- https://github.com/ainblockchain/ain-js/pull/129