### PR TITLE
Allow only positive and of up to 6 decimals transfer values

### DIFF
--- a/ain/utils/__init__.py
+++ b/ain/utils/__init__.py
@@ -45,7 +45,7 @@ def encodeVarInt(number: int) -> bytes:
 SIGNED_MESSAGE_PREFIX = "AINetwork Signed Message:\n"
 SIGNED_MESSAGE_PREFIX_BYTES = bytes(SIGNED_MESSAGE_PREFIX, "utf-8")
 SIGNED_MESSAGE_PREFIX_LENGTH = encodeVarInt(len(SIGNED_MESSAGE_PREFIX))
-AIN_HD_DERIVATION_PATH = "m/44'/412'/0'/0/"
+AIN_HD_DERIVATION_PATH = "m/44'/412'/0'/0/"  # The hardware wallet derivation path of AIN
 
 def getTimestamp() -> int:
     """Gets the current unix timestamp.

--- a/ain/utils/__init__.py
+++ b/ain/utils/__init__.py
@@ -45,6 +45,7 @@ def encodeVarInt(number: int) -> bytes:
 SIGNED_MESSAGE_PREFIX = "AINetwork Signed Message:\n"
 SIGNED_MESSAGE_PREFIX_BYTES = bytes(SIGNED_MESSAGE_PREFIX, "utf-8")
 SIGNED_MESSAGE_PREFIX_LENGTH = encodeVarInt(len(SIGNED_MESSAGE_PREFIX))
+# TODO(platfowner): Migrate to Ethereum HD derivation path 'm/44'/60'/0'/0/'.
 AIN_HD_DERIVATION_PATH = "m/44'/412'/0'/0/"  # The hardware wallet derivation path of AIN
 
 def getTimestamp() -> int:

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -270,6 +270,8 @@ class Wallet:
         """
         fromAddr = self.getImpliedAddress(fromAddress)
         toAddr = toChecksumAddress(toAddress)
+        if not value > 0 :
+            raise ValueError('Non-positive transfer value.')
         decimalCount = Wallet.countDecimals(value)
         if decimalCount > MAX_TRANSFERABLE_DECIMALS :
             raise ValueError(f'Transfer value of more than {MAX_TRANSFERABLE_DECIMALS} decimals.')

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -23,6 +23,8 @@ from ain.utils.v3keystore import V3Keystore, V3KeystoreOptions
 if TYPE_CHECKING:
     from ain.ain import Ain
 
+MAX_TRANSFERABLE_DECIMALS = 6;  # The maximum decimals of transferable values
+
 class Wallet:
     """Class for the AIN Blockchain wallet."""
 
@@ -268,6 +270,9 @@ class Wallet:
         """
         fromAddr = self.getImpliedAddress(fromAddress)
         toAddr = toChecksumAddress(toAddress)
+        decimalCount = Wallet.countDecimals(value)
+        if decimalCount > MAX_TRANSFERABLE_DECIMALS :
+            raise ValueError(f'Transfer value of more than {MAX_TRANSFERABLE_DECIMALS} decimals.')
         transferRef = self.ain.db.ref(f"/transfer/{fromAddr}/{toAddr}").push()
         return await transferRef.setValue(
             ValueOnlyTransactionInput(

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -224,12 +224,12 @@ class Wallet:
             addr = toChecksumAddress(address)
         return await self.ain.db.ref(f"/accounts/{addr}/balance").getValue()
 
-    async def transfer(self, toAddress: str, value: int, fromAddress: str = None, nonce: int = None, gas_price: int = None, isDryrun = False):
+    async def transfer(self, toAddress: str, value: float, fromAddress: str = None, nonce: int = None, gas_price: int = None, isDryrun = False):
         """Sends a transfer transaction to the network.
 
         Args:
             toAddress (str): The AIN blockchain address that wants to transfer AIN to.
-            value (int): The amount of the transferring AIN.
+            value (float): The amount of the transferring AIN.
             fromAddress (str, Optional): The AIN blockchain address that wants to transfer AIN from.
                 Defaults to `None`, transfer from the default account of the current wallet.
             nonce (int, Optional): The nonce of the transfer transaction.

--- a/ain/wallet.py
+++ b/ain/wallet.py
@@ -1,3 +1,5 @@
+import re
+import math
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 from ain.account import Account, Accounts
 from ain.types import (
@@ -57,6 +59,29 @@ class Wallet:
         if checksummed not in self.accounts:
             return ''
         return self.accounts[checksummed].public_key
+
+    @staticmethod
+    def countDecimals(value: float) -> int:
+        """Counts the given number's decimals.
+
+        Args:
+            value(float): The number.
+
+        Returns:
+            int: The decimal count.
+        """
+        valueString = str(value)
+        if math.floor(value) == value :
+            return 0
+        p = re.compile(r'^-{0,1}(\d*\.{0,1}\d*)e-(\d+)$')
+        matches = p.findall(valueString)
+        if len(matches) > 0 and len(matches[0]) == 2:
+            return int(matches[0][1]) + Wallet.countDecimals(float(matches[0][0]))
+        else :
+            parts = valueString.split('.')
+            if len(parts) >= 2 :
+                return len(parts[1])
+            return 0
 
     def create(self, numberOfAccounts: int):
         """Creates `numberOfAccounts` new accounts, and adds them to the wallet.

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -232,6 +232,32 @@ class TestWallet(TestCase):
         self.assertEqual(balanceBefore - 100, balanceAfter)
 
     @asyncTest
+    async def testTransferWithAZeroValue(self):
+        ain = Ain(testNode)
+        ain.wallet.addAndSetDefaultAccount(accountSk)
+        balanceBefore = await ain.wallet.getBalance()
+        try:
+            await ain.wallet.transfer(transferAddress, 0, nonce=-1)  # zero value
+            self.fail('should not happen')
+        except ValueError as e:
+            self.assertEqual(str(e), 'Non-positive transfer value.')
+        balanceAfter = await ain.wallet.getBalance()
+        self.assertEqual(balanceBefore, balanceAfter)  # NOT changed!
+
+    @asyncTest
+    async def testTransferWithANegativeValue(self):
+        ain = Ain(testNode)
+        ain.wallet.addAndSetDefaultAccount(accountSk)
+        balanceBefore = await ain.wallet.getBalance()
+        try:
+            await ain.wallet.transfer(transferAddress, -0.1, nonce=-1)  # negative value
+            self.fail('should not happen')
+        except ValueError as e:
+            self.assertEqual(str(e), 'Non-positive transfer value.')
+        balanceAfter = await ain.wallet.getBalance()
+        self.assertEqual(balanceBefore, balanceAfter)  # NOT changed!
+
+    @asyncTest
     async def testTransferWithAValueOfUpTo6Decimals(self):
         ain = Ain(testNode)
         ain.wallet.addAndSetDefaultAccount(accountSk)

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -231,6 +231,28 @@ class TestWallet(TestCase):
         balanceAfter = await ain.wallet.getBalance()
         self.assertEqual(balanceBefore - 100, balanceAfter)
 
+    @asyncTest
+    async def testTransferWithAValueOfUpTo6Decimals(self):
+        ain = Ain(testNode)
+        ain.wallet.addAndSetDefaultAccount(accountSk)
+        balanceBefore = await ain.wallet.getBalance()
+        await ain.wallet.transfer(transferAddress, 0.0001, nonce=-1)  # of 4 decimals
+        balanceAfter = await ain.wallet.getBalance()
+        self.assertEqual(balanceBefore - 0.0001, balanceAfter)
+
+    @asyncTest
+    async def testTransferWithAValueOfMoreThan6Decimals(self):
+        ain = Ain(testNode)
+        ain.wallet.addAndSetDefaultAccount(accountSk)
+        balanceBefore = await ain.wallet.getBalance()
+        try:
+            await ain.wallet.transfer(transferAddress, 0.0000001, nonce=-1)  # of 7 decimals
+            self.fail('should not happen')
+        except ValueError as e:
+            self.assertEqual(str(e), 'Transfer value of more than 6 decimals.')
+        balanceAfter = await ain.wallet.getBalance()
+        self.assertEqual(balanceBefore, balanceAfter)  # NOT changed!
+
     def testChainId(self):
         ain = Ain(testNode, 0)
         ain.wallet.addAndSetDefaultAccount(accountSk)

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -4,6 +4,7 @@ import re
 from unittest import TestCase
 from snapshottest import TestCase as SnapshotTestCase
 from ain.ain import Ain
+from ain.ain import Wallet
 from ain.provider import JSON_RPC_ENDPOINT
 from ain.utils import *
 from ain.utils.v3keystore import *
@@ -65,6 +66,69 @@ class TestNetwork(TestCase):
         self.assertEqual(res["result"], True)
 
 class TestWallet(TestCase):
+    def testCountDecimals(self):
+        self.assertEqual(Wallet.countDecimals(0), 0)  # '0'
+        self.assertEqual(Wallet.countDecimals(1), 0)  # '1'
+        self.assertEqual(Wallet.countDecimals(10), 0)  # '10'
+        self.assertEqual(Wallet.countDecimals(100), 0)  # '100'
+        self.assertEqual(Wallet.countDecimals(1000), 0)  # '1000'
+        self.assertEqual(Wallet.countDecimals(10000), 0)  # '10000'
+        self.assertEqual(Wallet.countDecimals(100000), 0)  # '100000'
+        self.assertEqual(Wallet.countDecimals(1000000), 0)  # '1000000'
+        self.assertEqual(Wallet.countDecimals(10000000), 0)  # '10000000'
+        self.assertEqual(Wallet.countDecimals(100000000), 0)  # '100000000'
+        self.assertEqual(Wallet.countDecimals(1000000000), 0)  # '1000000000'
+        self.assertEqual(Wallet.countDecimals(1234567890), 0)  # '1234567890'
+        self.assertEqual(Wallet.countDecimals(-1), 0)  # '-1'
+        self.assertEqual(Wallet.countDecimals(-1000000000), 0)  # '-1000000000'
+        self.assertEqual(Wallet.countDecimals(11), 0)  # '11'
+        self.assertEqual(Wallet.countDecimals(101), 0)  # '101'
+        self.assertEqual(Wallet.countDecimals(1001), 0)  # '1001'
+        self.assertEqual(Wallet.countDecimals(10001), 0)  # '10001'
+        self.assertEqual(Wallet.countDecimals(100001), 0)  # '100001'
+        self.assertEqual(Wallet.countDecimals(1000001), 0)  # '1000001'
+        self.assertEqual(Wallet.countDecimals(10000001), 0)  # '10000001'
+        self.assertEqual(Wallet.countDecimals(100000001), 0)  # '100000001'
+        self.assertEqual(Wallet.countDecimals(1000000001), 0)  # '1000000001'
+        self.assertEqual(Wallet.countDecimals(-11), 0)  # '-11'
+        self.assertEqual(Wallet.countDecimals(-1000000001), 0)  # '-1000000001'
+        self.assertEqual(Wallet.countDecimals(0.1), 1)  # '0.1'
+        self.assertEqual(Wallet.countDecimals(0.01), 2)  # '0.01'
+        self.assertEqual(Wallet.countDecimals(0.001), 3)  # '0.001'
+        self.assertEqual(Wallet.countDecimals(0.0001), 4)  # '0.0001'
+        self.assertEqual(Wallet.countDecimals(0.00001), 5)  # '1e-05'
+        self.assertEqual(Wallet.countDecimals(0.000001), 6)  # '1e-06'
+        self.assertEqual(Wallet.countDecimals(0.0000001), 7)  # '1e-07'
+        self.assertEqual(Wallet.countDecimals(0.00000001), 8)  # '1e-08'
+        self.assertEqual(Wallet.countDecimals(0.000000001), 9)  # '1e-09'
+        self.assertEqual(Wallet.countDecimals(0.0000000001), 10)  # '1e-10'
+        self.assertEqual(Wallet.countDecimals(-0.1), 1)  # '-0.1'
+        self.assertEqual(Wallet.countDecimals(-0.0000000001), 10)  # '-1e-10'
+        self.assertEqual(Wallet.countDecimals(1.2), 1)  # '1.2'
+        self.assertEqual(Wallet.countDecimals(0.12), 2)  # '0.12'
+        self.assertEqual(Wallet.countDecimals(0.012), 3)  # '0.012'
+        self.assertEqual(Wallet.countDecimals(0.0012), 4)  # '0.0012'
+        self.assertEqual(Wallet.countDecimals(0.00012), 5)  # '0.00012'
+        self.assertEqual(Wallet.countDecimals(0.000012), 6)  # '1.2e-05'
+        self.assertEqual(Wallet.countDecimals(0.0000012), 7)  # '1.2e-06'
+        self.assertEqual(Wallet.countDecimals(0.00000012), 8)  # '1.2e-07'
+        self.assertEqual(Wallet.countDecimals(0.000000012), 9)  # '1.2e-08'
+        self.assertEqual(Wallet.countDecimals(0.0000000012), 10)  # '1.2e-09'
+        self.assertEqual(Wallet.countDecimals(0.00000000012), 11)  # '1.2e-10'
+        self.assertEqual(Wallet.countDecimals(-1.2), 1)  # '-1.2'
+        self.assertEqual(Wallet.countDecimals(-0.00000000012), 11)  # '-1.2e-10'
+        self.assertEqual(Wallet.countDecimals(1.03), 2)  # '1.03'
+        self.assertEqual(Wallet.countDecimals(1.003), 3)  # '1.003'
+        self.assertEqual(Wallet.countDecimals(1.0003), 4)  # '1.0003'
+        self.assertEqual(Wallet.countDecimals(1.00003), 5)  # '1.00003'
+        self.assertEqual(Wallet.countDecimals(1.000003), 6)  # '1.000003'
+        self.assertEqual(Wallet.countDecimals(1.0000003), 7)  # '1.0000003'
+        self.assertEqual(Wallet.countDecimals(1.00000003), 8)  # '1.00000003'
+        self.assertEqual(Wallet.countDecimals(1.000000003), 9)  # '1.000000003'
+        self.assertEqual(Wallet.countDecimals(1.0000000003), 10)  # '1.0000000003'
+        self.assertEqual(Wallet.countDecimals(-1.03), 2)  # '-1.03'
+        self.assertEqual(Wallet.countDecimals(-1.0000000003), 10)  # '-1.0000000003'
+
     def testCreateAccount(self):
         ain = Ain(testNode)
         ain.wallet.create(2)


### PR DESCRIPTION
Change summary:
- Change transfer value type to float
- Allow transfer values of only up to 6 decimals
- Allow only positive transfer values

Related PRs:
- https://github.com/ainblockchain/ain-js/pull/152
- https://github.com/ainblockchain/ain-js/pull/153

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1208