### PR TITLE
Add missing methods for Database JSON RPC APIs

### DIFF
--- a/ain/db/ref.py
+++ b/ain/db/ref.py
@@ -418,7 +418,7 @@ class Reference:
         """Fetches the state proof of a global blockchain state path.
 
         Args:
-            params (StateProofInput): The state info input object.
+            params (StateInfoInput): The state info input object.
             
         Returns:
             The return value of the blockchain API.
@@ -432,7 +432,7 @@ class Reference:
         """Fetches the proof hash of a global blockchain state path.
 
         Args:
-            params (StateProofInput): The state info input object.
+            params (StateInfoInput): The state info input object.
             
         Returns:
             The return value of the blockchain API.
@@ -446,7 +446,7 @@ class Reference:
         """Fetches the state information of a global blockchain state path.
 
         Args:
-            params (StateProofInput): The state info input object.
+            params (StateInfoInput): The state info input object.
             
         Returns:
             The return value of the blockchain API.

--- a/ain/db/ref.py
+++ b/ain/db/ref.py
@@ -418,7 +418,7 @@ class Reference:
         """Fetches the state proof of a global blockchain state path.
 
         Args:
-            params (MatchInput): The state info input object.
+            params (StateProofInput): The state info input object.
             
         Returns:
             The return value of the blockchain API.
@@ -427,6 +427,20 @@ class Reference:
         if params is not None and hasattr(params, "ref"):
             ref = Reference.extendPath(ref, getattr(params, "ref", None))
         return await self._ain.provider.send("ain_getStateProof", {"ref": ref})
+
+    async def getProofHash(self, params: StateInfoInput = None) -> Any:
+        """Fetches the proof hash of a global blockchain state path.
+
+        Args:
+            params (StateProofInput): The state info input object.
+            
+        Returns:
+            The return value of the blockchain API.
+        """
+        ref = self._path
+        if params is not None and hasattr(params, "ref"):
+            ref = Reference.extendPath(ref, getattr(params, "ref", None))
+        return await self._ain.provider.send("ain_getProofHash", {"ref": ref})
 
     @staticmethod
     def buildGetRequest(type: GetOperationType, ref: str, options: GetOptions = None) -> dict:

--- a/ain/db/ref.py
+++ b/ain/db/ref.py
@@ -12,6 +12,7 @@ from ain.types import (
     EvalRuleInput,
     EvalOwnerInput,
     MatchInput,
+    StateInfoInput,
     GetOptions,
 )
 from ain.db.push_id import PushId
@@ -412,6 +413,20 @@ class Reference:
         if params is not None and hasattr(params, "ref"):
             ref = Reference.extendPath(ref, getattr(params, "ref", None))
         return await self._ain.provider.send("ain_matchOwner", {"ref": ref})
+
+    async def getStateProof(self, params: StateInfoInput = None) -> Any:
+        """Fetches the state proof of a global blockchain state path.
+
+        Args:
+            params (MatchInput): The state info input object.
+            
+        Returns:
+            The return value of the blockchain API.
+        """
+        ref = self._path
+        if params is not None and hasattr(params, "ref"):
+            ref = Reference.extendPath(ref, getattr(params, "ref", None))
+        return await self._ain.provider.send("ain_getStateProof", {"ref": ref})
 
     @staticmethod
     def buildGetRequest(type: GetOperationType, ref: str, options: GetOptions = None) -> dict:

--- a/ain/db/ref.py
+++ b/ain/db/ref.py
@@ -442,6 +442,20 @@ class Reference:
             ref = Reference.extendPath(ref, getattr(params, "ref", None))
         return await self._ain.provider.send("ain_getProofHash", {"ref": ref})
 
+    async def getStateInfo(self, params: StateInfoInput = None) -> Any:
+        """Fetches the state information of a global blockchain state path.
+
+        Args:
+            params (StateProofInput): The state info input object.
+            
+        Returns:
+            The return value of the blockchain API.
+        """
+        ref = self._path
+        if params is not None and hasattr(params, "ref"):
+            ref = Reference.extendPath(ref, getattr(params, "ref", None))
+        return await self._ain.provider.send("ain_getStateInfo", {"ref": ref})
+
     @staticmethod
     def buildGetRequest(type: GetOperationType, ref: str, options: GetOptions = None) -> dict:
         """Builds a get request.

--- a/ain/types.py
+++ b/ain/types.py
@@ -450,3 +450,16 @@ class MatchInput:
             self.ref = ref
         if is_global is not None:
             self.is_global = is_global
+
+class StateInfoInput:
+    """Class for the state information input."""
+
+    ref: Optional[str]
+    """The path that you want to query with."""
+
+    def __init__(
+        self,
+        ref: str = None,
+    ):
+        if ref is not None:
+            self.ref = ref

--- a/tests/snapshots/snap_test_ain.py
+++ b/tests/snapshots/snap_test_ain.py
@@ -254,6 +254,8 @@ snapshots['TestDatabase::test03EvalRuleTrue 1'] = {
     }
 }
 
+snapshots['TestDatabase::test03GetProofHash 1'] = '0x88496dfee3566db91f487aa4cbf69a0c42a3e2a5d0a65bfd4897d699e8734785'
+
 snapshots['TestDatabase::test03MatchFunction 1'] = {
     'matched_config': {
         'config': {

--- a/tests/snapshots/snap_test_ain.py
+++ b/tests/snapshots/snap_test_ain.py
@@ -266,26 +266,6 @@ snapshots['TestDatabase::test03GetStateInfo 1'] = {
     '#version': 'erased'
 }
 
-snapshots['TestDatabase::test03GetStateUsage 1'] = {
-    'available': {
-        'tree_bytes': 25000000,
-        'tree_height': 30,
-        'tree_size': 156250
-    },
-    'protoVer': 'erased',
-    'staking': {
-        'app': 0,
-        'total': 2,
-        'unstakeable': 0
-    },
-    'usage': {
-        'tree_bytes': 0,
-        'tree_height': 0,
-        'tree_max_siblings': 0,
-        'tree_size': 0
-    }
-}
-
 snapshots['TestDatabase::test03MatchFunction 1'] = {
     'matched_config': {
         'config': {

--- a/tests/snapshots/snap_test_ain.py
+++ b/tests/snapshots/snap_test_ain.py
@@ -256,6 +256,16 @@ snapshots['TestDatabase::test03EvalRuleTrue 1'] = {
 
 snapshots['TestDatabase::test03GetProofHash 1'] = '0x88496dfee3566db91f487aa4cbf69a0c42a3e2a5d0a65bfd4897d699e8734785'
 
+snapshots['TestDatabase::test03GetStateInfo 1'] = {
+    '#num_children': 1,
+    '#state_ph': '0x985a1f057d5047b1dee392127eb776571fbbe79da7ae6114f8f8f18c4f786135',
+    '#tree_bytes': 1840,
+    '#tree_height': 2,
+    '#tree_max_siblings': 1,
+    '#tree_size': 3,
+    '#version': 'POOL:0:1:1711333198584:0'
+}
+
 snapshots['TestDatabase::test03MatchFunction 1'] = {
     'matched_config': {
         'config': {

--- a/tests/snapshots/snap_test_ain.py
+++ b/tests/snapshots/snap_test_ain.py
@@ -263,7 +263,27 @@ snapshots['TestDatabase::test03GetStateInfo 1'] = {
     '#tree_height': 2,
     '#tree_max_siblings': 1,
     '#tree_size': 3,
-    '#version': 'POOL:0:1:1711333198584:0'
+    '#version': 'erased'
+}
+
+snapshots['TestDatabase::test03GetStateUsage 1'] = {
+    'available': {
+        'tree_bytes': 25000000,
+        'tree_height': 30,
+        'tree_size': 156250
+    },
+    'protoVer': 'erased',
+    'staking': {
+        'app': 0,
+        'total': 2,
+        'unstakeable': 0
+    },
+    'usage': {
+        'tree_bytes': 0,
+        'tree_height': 0,
+        'tree_max_siblings': 0,
+        'tree_size': 0
+    }
 }
 
 snapshots['TestDatabase::test03MatchFunction 1'] = {

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -303,6 +303,14 @@ class TestCore(TestCase):
         block = await self.ain.getBlock(4)
         hash = block.get("hash", "")
         self.assertDictEqual(await self.ain.getValidators(hash), validators)
+    
+    @asyncTest
+    async def test00GetStateUsage(self):
+        # with an app that does not exist yet
+        erased = eraseProtoVer(await self.ain.getStateUsage("test_new"))
+        self.assertIsNotNone(erased["available"])
+        self.assertIsNotNone(erased["usage"])
+        self.assertIsNotNone(erased["staking"])
 
     @asyncTest
     async def test00ValidateAppNameTrue(self):
@@ -929,9 +937,4 @@ class TestDatabase(SnapshotTestCase):
     @asyncTest
     async def test03GetStateInfo(self):
         self.matchSnapshot(eraseStateVersion(await self.ain.db.ref('/rules/transfer/$from/$to/$key/value').getStateInfo()))
-    
-    @asyncTest
-    async def test03GetStateUsage(self):
-        # with an app that does not exist yet
-        self.matchSnapshot(eraseProtoVer(await self.ain.getStateUsage("test_new")))
 

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -923,4 +923,8 @@ class TestDatabase(SnapshotTestCase):
     @asyncTest
     async def test03GetProofHash(self):
         self.matchSnapshot(await self.ain.db.ref('/values/blockchain_params').getProofHash())
+
+    @asyncTest
+    async def test03GetStateInfo(self):
+        self.matchSnapshot(await self.ain.db.ref('/rules/transfer/$from/$to/$key/value').getStateInfo())
     

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -910,3 +910,7 @@ class TestDatabase(SnapshotTestCase):
     async def test03MatchOwner(self):
         self.matchSnapshot(await self.ain.db.ref(self.allowedPath).matchOwner())
     
+    @asyncTest
+    async def test03GetStateProof(self):
+        self.assertIsNotNone(await self.ain.db.ref('/values/blockchain_params').getStateProof())
+    

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -26,6 +26,8 @@ from .util import (
     getRequest,
     postRequest,
     waitUntilTxFinalized,
+    eraseProtoVer,
+    eraseStateVersion,
 )
 
 TX_PATTERN = re.compile("0x[0-9a-fA-F]{64}")
@@ -926,5 +928,10 @@ class TestDatabase(SnapshotTestCase):
 
     @asyncTest
     async def test03GetStateInfo(self):
-        self.matchSnapshot(await self.ain.db.ref('/rules/transfer/$from/$to/$key/value').getStateInfo())
+        self.matchSnapshot(eraseStateVersion(await self.ain.db.ref('/rules/transfer/$from/$to/$key/value').getStateInfo()))
     
+    @asyncTest
+    async def test03GetStateUsage(self):
+        # with an app that does not exist yet
+        self.matchSnapshot(eraseProtoVer(await self.ain.getStateUsage("test_new")))
+

--- a/tests/test_ain.py
+++ b/tests/test_ain.py
@@ -914,3 +914,13 @@ class TestDatabase(SnapshotTestCase):
     async def test03GetStateProof(self):
         self.assertIsNotNone(await self.ain.db.ref('/values/blockchain_params').getStateProof())
     
+    @asyncTest
+    async def test03GetStateProofWithInput(self):
+        self.assertIsNotNone(await self.ain.db.ref('/values/blockchain_params').getStateProof(StateInfoInput(
+            ref="resource"
+        )))
+
+    @asyncTest
+    async def test03GetProofHash(self):
+        self.matchSnapshot(await self.ain.db.ref('/values/blockchain_params').getProofHash())
+    

--- a/tests/util.py
+++ b/tests/util.py
@@ -39,3 +39,7 @@ async def waitUntilTxFinalized(testNode: str, txHash: str) -> bool:
 def eraseProtoVer(ret: dict):
     ret["protoVer"] = "erased"
     return ret
+
+def eraseStateVersion(ret: dict):
+    ret["#version"] = "erased"
+    return ret


### PR DESCRIPTION
Change summary:
- Add missing methods for Database JSON RPC APIs (see https://github.com/ainblockchain/ain-blockchain/blob/master/JSON_RPC_API.md) 

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1252